### PR TITLE
Cedmt 115 voy a implementar un invariant para validar que el valor sea o

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -408,3 +408,6 @@ docs/
 
 # Novafuria Agents
 .novafuria/**/tmp
+
+# NuGet configuration files
+nuget.config

--- a/Cedeira.Essentials.NET-unittests/Diagnostics/Invariants/InvariantValidatorTests.cs
+++ b/Cedeira.Essentials.NET-unittests/Diagnostics/Invariants/InvariantValidatorTests.cs
@@ -305,7 +305,6 @@ namespace Cedeira.Essentials.NET.Diagnostics.Invariants
 
         [TestMethod]
         [ExpectedException(typeof(ArgumentNullException))]
-
         public void LessThanShouldPass_WhenEspectNull()
         {
 
@@ -331,6 +330,37 @@ namespace Cedeira.Essentials.NET.Diagnostics.Invariants
         {
             Invariants.For("B").GreaterThan("A");
         }
+
+        [TestMethod]
+        [ExpectedException(typeof(InvalidOperationException))]
+        public void LessThanShouldPass_WhenValueIsObject()
+        {
+            object Objeto = new object();
+            Invariants.For<object?>(Objeto).LessThan(10);
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(InvalidOperationException))]
+        public void GreaterThanShouldPass_WhenValueIsObject()
+        {
+            object Objeto = new object();
+            Invariants.For(Objeto).LessThan(10);
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(InvalidOperationException))]
+        public void LessThanShouldPass_WhenEspectIsObject()
+        {
+            object Objeto = new object();
+            Invariants.For<object?>(5).LessThan(Objeto);
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(InvalidOperationException))]
+        public void GreaterThanShouldPass_WhenEspectIsObject()
+        {
+            object Objeto = new object();
+            Invariants.For <object?>(5).LessThan(Objeto);
+        }
     }
 }
-

--- a/Cedeira.Essentials.NET-unittests/Diagnostics/Invariants/InvariantValidatorTests.cs
+++ b/Cedeira.Essentials.NET-unittests/Diagnostics/Invariants/InvariantValidatorTests.cs
@@ -5,6 +5,7 @@ namespace Cedeira.Essentials.NET.Diagnostics.Invariants
     [TestClass]
     public class InvariantValidatorTests
     {
+       
         [TestMethod]
         public void IsEqual_ShouldPass_WhenValuesAreEqual()
         {
@@ -174,29 +175,85 @@ namespace Cedeira.Essentials.NET.Diagnostics.Invariants
         [TestMethod]
         public void LessThan_ShouldPass_WhenValueIsLessThanMax()
         {
-            Invariants.For(5).LessThan(10);
+            Invariants.For(-1).LessThan(0);
         }
 
         [TestMethod]
         [ExpectedException(typeof(ArgumentException))]
-        public void LessThan_ShouldPass_WhenValueIsLessThanMax()
+        public void LessThan_ShouldPass_WhenValueIsLessThanMaxFail()
         {
             Invariants.For(10).LessThan(5);
         }
 
         [TestMethod]
-        public void GreaterThan_ShouldPass_WhenValueIsLessThanMax()
+        public void GreaterThan_ShouldPass_WhenValueIsGreaterThanMax()
         {
             Invariants.For(10).GreaterThan(5);
         }
 
         [TestMethod]
         [ExpectedException(typeof(ArgumentException))]
-        public void GreaterThan_ShouldPass_WhenValueIsLessThanMax()
+        public void GreaterThan_ShouldPass_WhenValueIsGreaterThanMaxFail()
         {
-            Invariants.For(5).GreaterThan(10);
+            Invariants.For(-1).GreaterThan(0);
         }
 
+        [TestMethod]
+        public void LessThanShouldPass_WhenValueDatetime()
+        {
+            var today = DateTime.Now.Date;
+            Invariants.For(today).LessThan(today.AddDays(1));
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentException))]
+        public void LessThanShouldPass_WhenValueDatetimeFail()
+        {
+            var today = DateTime.Now.Date;
+            Invariants.For(today.AddDays(1)).LessThan(today);
+        }
+
+
+        [TestMethod]
+        public void LessThanShouldPass_WhenValueString()
+        {
+            Invariants.For("A").LessThan("B");
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentException))]
+        public void LessThanShouldPass_WhenValueStringFail()
+        {
+            Invariants.For("B").LessThan("A");
+        }
+
+        [TestMethod]
+        public void GreaterThanShouldPass_WhenValueDatetime()
+        {
+            var today = DateTime.Now.Date;
+            Invariants.For(today.AddDays(1)).GreaterThan(today); 
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentException))]
+        public void GreaterThanShouldPass_WhenValueDatetimeFail()
+        {
+            var today = DateTime.Now.Date;
+            Invariants.For(today).GreaterThan(today.AddDays(1));
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentException))]
+        public void GreaterThanShouldPass_WhenValueStringFail()
+        {
+            Invariants.For("A").GreaterThan("B");
+        }
+
+        [TestMethod]
+        public void GreaterThanShouldPass_WhenValueString()
+        {
+            Invariants.For("B").GreaterThan("A");
+        }
     }
 }
 

--- a/Cedeira.Essentials.NET-unittests/Diagnostics/Invariants/InvariantValidatorTests.cs
+++ b/Cedeira.Essentials.NET-unittests/Diagnostics/Invariants/InvariantValidatorTests.cs
@@ -213,6 +213,21 @@ namespace Cedeira.Essentials.NET.Diagnostics.Invariants
             Invariants.For(today.AddDays(1)).LessThan(today);
         }
 
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentNullException))]
+        public void LessThanShouldPass_WhenValueDatetimeNull()
+        {
+            var today = DateTime.Now.Date;
+            Invariants.For<DateTime?>(null).GreaterThan(today.AddDays(1));
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentNullException))]
+        public void LessThanShouldPass_WhenEspectDatetimeNull()
+        {
+            var today = DateTime.Now.Date;
+            Invariants.For<DateTime?>(today).LessThan(null);
+        }
 
         [TestMethod]
         public void LessThanShouldPass_WhenValueString()
@@ -225,6 +240,13 @@ namespace Cedeira.Essentials.NET.Diagnostics.Invariants
         public void LessThanShouldPass_WhenValueStringFail()
         {
             Invariants.For("B").LessThan("A");
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentNullException))]
+        public void LessThanShouldPass_WhenExpectedStringNull()
+        {
+            Invariants.For("A").LessThan(null);
         }
 
         [TestMethod]
@@ -243,10 +265,65 @@ namespace Cedeira.Essentials.NET.Diagnostics.Invariants
         }
 
         [TestMethod]
+        [ExpectedException(typeof(ArgumentNullException))]
+        public void GreaterThanShouldPass_WhenValueDatetimeNull()
+        {
+            var today = DateTime.Now.Date;
+            Invariants.For<DateTime?>(null).GreaterThan(today.AddDays(1));
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentNullException))]
+        public void GreaterThanShouldPass_WhenEspectDatetimeNull()
+        {
+            var today = DateTime.Now.Date;
+            Invariants.For<DateTime?>(today).GreaterThan(null);
+        }
+
+        [TestMethod]
         [ExpectedException(typeof(ArgumentException))]
         public void GreaterThanShouldPass_WhenValueStringFail()
         {
             Invariants.For("A").GreaterThan("B");
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentNullException))]
+        
+        public void LessThanShouldPass_WhenValueNull()
+        {
+            
+            Invariants.For<int?>(null).LessThan(0);
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentNullException))]
+        public void GreaterThanShouldPass_WhenValueNull()
+        {
+            Invariants.For<int?>(null).GreaterThan(0);
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentNullException))]
+
+        public void LessThanShouldPass_WhenEspectNull()
+        {
+
+            Invariants.For<int?>(5).LessThan(null);
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentNullException))]
+        public void GreaterThanShouldPass_WhenEspectNull()
+        {
+            Invariants.For<int?>(10).GreaterThan(null);
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentNullException))]
+        public void GreaterThanShouldPass_WhenExpectedStringNull()
+        {
+            Invariants.For("A").GreaterThan(null);
         }
 
         [TestMethod]

--- a/Cedeira.Essentials.NET-unittests/Diagnostics/Invariants/InvariantValidatorTests.cs
+++ b/Cedeira.Essentials.NET-unittests/Diagnostics/Invariants/InvariantValidatorTests.cs
@@ -171,6 +171,32 @@ namespace Cedeira.Essentials.NET.Diagnostics.Invariants
             , "Value must be positive.");
         }
 
+        [TestMethod]
+        public void LessThan_ShouldPass_WhenValueIsLessThanMax()
+        {
+            Invariants.For(5).LessThan(10);
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentException))]
+        public void LessThan_ShouldPass_WhenValueIsLessThanMax()
+        {
+            Invariants.For(10).LessThan(5);
+        }
+
+        [TestMethod]
+        public void GreaterThan_ShouldPass_WhenValueIsLessThanMax()
+        {
+            Invariants.For(10).GreaterThan(5);
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentException))]
+        public void GreaterThan_ShouldPass_WhenValueIsLessThanMax()
+        {
+            Invariants.For(5).GreaterThan(10);
+        }
+
     }
 }
 

--- a/Cedeira.Essentials.NET/Diagnostics/Invariants/InvariantValidator.cs
+++ b/Cedeira.Essentials.NET/Diagnostics/Invariants/InvariantValidator.cs
@@ -215,7 +215,63 @@ namespace Cedeira.Essentials.NET.Diagnostics.Invariants
             }
             return this;
         }
+        /// <summary>
+        /// Verifica que el valor no sea menor a cero.
+        /// Lanza una FormatException si el valor es menor a cero.
+        /// </summary>
+        /// <param name="expected">El patrón de expresión regular con el que se debe comparar el valor.</param>
+        /// <returns>El propio InvariantValidator para permitir chaining.</returns>
+        public InvariantValidator<T> LessThan(T expected)
+        {
+            if (_value == null)
+                throw new ArgumentNullException(nameof(_value), "Value to compare cannot be null.");
 
+            if (expected == null)
+                throw new ArgumentNullException(nameof(expected), "Expected value cannot be null.");
+
+            if (_value is IComparable<T> comparable)
+            {
+                if (comparable.CompareTo(expected) > 0)
+                {
+                    throw new ArgumentException("value can not be higher than expected");
+                }
+            }
+            else
+            {
+                throw new InvalidOperationException($"Type {typeof(T).Name} does not support comparison.");
+            }
+
+            return this;
+        }
+        /// <summary>
+        /// Verifica que el valor no sea mayor a cero.
+        /// Lanza una FormatException si el valor es mayor a cero.
+        /// </summary>
+        /// <param name="expected">El patrón de expresión regular con el que se debe comparar el valor.</param>
+        /// <returns>El propio InvariantValidator para permitir chaining.</returns>
+        public InvariantValidator<T> GreaterThan(T expected)
+        {
+            if (_value == null)
+                throw new ArgumentNullException(nameof(_value), "Value to compare cannot be null.");
+
+            if (expected == null)
+                throw new ArgumentNullException(nameof(expected), "Expected value cannot be null.");
+
+            if (_value is IComparable<T> comparable)
+            {
+                if (comparable.CompareTo(expected) < 0)
+                {
+                    throw new ArgumentException("value can not be less than expected");
+                }
+            }
+            else
+            {
+                throw new InvalidOperationException($"Type {typeof(T).Name} does not support comparison.");
+            }
+
+            return this;
+        }
+        
         /// <summary>
         /// Método Helper Privado para validar mensajes de error
         /// </summary>

--- a/Cedeira.Essentials.NET/Diagnostics/Invariants/InvariantValidator.cs
+++ b/Cedeira.Essentials.NET/Diagnostics/Invariants/InvariantValidator.cs
@@ -1,4 +1,5 @@
-﻿using System.Text.RegularExpressions;
+﻿using System;
+using System.Text.RegularExpressions;
 
 namespace Cedeira.Essentials.NET.Diagnostics.Invariants
 {
@@ -216,11 +217,14 @@ namespace Cedeira.Essentials.NET.Diagnostics.Invariants
             return this;
         }
         /// <summary>
-        /// Verifica que el valor no sea menor a cero.
-        /// Lanza una FormatException si el valor es menor a cero.
+        /// Compara _value con expected.
+        /// Lanza una FormatException Si _value > expected.
+        /// Si no es comparable, lanza excepción de tipo.
+        /// Si ambos son comparables y válidos, retorna this para permitir encadenamiento
         /// </summary>
         /// <param name="expected">El patrón de expresión regular con el que se debe comparar el valor.</param>
         /// <returns>El propio InvariantValidator para permitir chaining.</returns>
+ 
         public InvariantValidator<T> LessThan(T expected)
         {
             if (_value == null)
@@ -244,8 +248,10 @@ namespace Cedeira.Essentials.NET.Diagnostics.Invariants
             return this;
         }
         /// <summary>
-        /// Verifica que el valor no sea mayor a cero.
-        /// Lanza una FormatException si el valor es mayor a cero.
+        /// Compara _value con expected.
+        /// Lanza una FormatException Si _value < expected.
+        /// Si no es comparable, lanza excepción de tipo.
+        /// Si ambos son comparables y válidos, retorna this para permitir encadenamiento.
         /// </summary>
         /// <param name="expected">El patrón de expresión regular con el que se debe comparar el valor.</param>
         /// <returns>El propio InvariantValidator para permitir chaining.</returns>

--- a/Cedeira.Essentials.NET/Diagnostics/Invariants/InvariantValidator.cs
+++ b/Cedeira.Essentials.NET/Diagnostics/Invariants/InvariantValidator.cs
@@ -233,18 +233,12 @@ namespace Cedeira.Essentials.NET.Diagnostics.Invariants
             if (expected == null)
                 throw new ArgumentNullException(nameof(expected), "Expected value cannot be null.");
 
-            if (_value is IComparable<T> comparable)
-            {
-                if (comparable.CompareTo(expected) > 0)
-                {
-                    throw new ArgumentException("value can not be higher than expected");
-                }
-            }
-            else
-            {
+            if (!(_value is IComparable<T> comparable))
                 throw new InvalidOperationException($"Type {typeof(T).Name} does not support comparison.");
+            if (comparable.CompareTo(expected) > 0)
+            {
+                throw new ArgumentException("value can not be higher than expected");
             }
-
             return this;
         }
 
@@ -264,18 +258,12 @@ namespace Cedeira.Essentials.NET.Diagnostics.Invariants
             if (expected == null)
                 throw new ArgumentNullException(nameof(expected), "Expected value cannot be null.");
 
-            if (_value is IComparable<T> comparable)
-            {
-                if (comparable.CompareTo(expected) < 0)
-                {
-                    throw new ArgumentException("value can not be less than expected");
-                }
-            }
-            else
-            {
+            if (!(_value is IComparable<T> comparable))
                 throw new InvalidOperationException($"Type {typeof(T).Name} does not support comparison.");
+            if (comparable.CompareTo(expected) < 0)
+            {
+                throw new ArgumentException("value can not be less than expected");
             }
-
             return this;
         }
         

--- a/Cedeira.Essentials.NET/Diagnostics/Invariants/InvariantValidator.cs
+++ b/Cedeira.Essentials.NET/Diagnostics/Invariants/InvariantValidator.cs
@@ -247,14 +247,15 @@ namespace Cedeira.Essentials.NET.Diagnostics.Invariants
 
             return this;
         }
+
         /// <summary>
-        /// Compara _value con expected.
-        /// Lanza una FormatException Si _value < expected.
-        /// Si no es comparable, lanza excepción de tipo.
-        /// Si ambos son comparables y válidos, retorna this para permitir encadenamiento.
+        /// Compara el valor actual (_value) con el valor esperado.
+        /// Lanza una ArgumentException si _value es menor que expected.
+        /// Si el tipo T no implementa IComparable,lanza InvalidOperationException.
+        /// Si ambos valores son válidos y comparables, retorna la instancia actual para permitir encadenamiento.
         /// </summary>
-        /// <param name="expected">El patrón de expresión regular con el que se debe comparar el valor.</param>
-        /// <returns>El propio InvariantValidator para permitir chaining.</returns>
+        /// <param name="expected">El valor con el que se debe comparar el valor actual.</param>
+        /// <returns>La instancia actual de InvariantValidator para permitir encadenamiento (chaining).</returns>
         public InvariantValidator<T> GreaterThan(T expected)
         {
             if (_value == null)


### PR DESCRIPTION
# Description

En este invariant se incorporaron dos métodos uno es el LessThan y el otro es el GreaterThan. Se decidió utilizar el CompareTo que justamente compara el _value con expected. En ambos métodos se chequea si el valor actual (_value) es nulo, si lo es, lanza un error. Y se chequea si el valor esperado (expected) es nulo, si lo es, lanza un error. Luego verifica si el valor actual puede ser comparado para eso utiliza la interfaz IComparable<T>.

En el caso del LessThan el método verifica que un valor sea menor o igual al valor esperado. Es decir Si el valor actual (_value) es mayor que el esperado (expected), lanza un error. Esto permite utilizarlo para el objetivo inicial que era obtener una excepción si el valor era negativo o sea que el valor comparado sea menor a cero.  Por ejemplo supongamos que T es int, y _value es 0 se valida de este modo:

**var validator = new InvariantValidator<int>(0);
validator.LessThan(10); // OK
validator.LessThan(-3);  // Lanza error: 0 > -3**

El método GreaterThan realiza la operación inversa. Supongamos que T es int, y _value es 5:

**var validator = new InvariantValidator<int>(5);
validator.GreaterThan(3); // OK
validator.GreaterThan(10);  // Lanza error: 5 < 10**

Tambien nos permite comparar otros tipos ademas del int, long, decimal, etc. siempre que sean primitivos. Así podremos comparar valores de tipo fecha o string. Si el tipo no es primitivo ambos métodos lanzan una excepción de tipo. Y si ambos son comparables y válidos, retorna this para permitir encadenamiento. 
